### PR TITLE
Kinda big refactoring

### DIFF
--- a/src/frontend/core.cljs
+++ b/src/frontend/core.cljs
@@ -2,6 +2,7 @@
   (:require [frontend.devtools :as devtools]
             [frontend.todos :as todos]
             [frontend.persistence-middleware :as persistence]
+            [frontend.ui :as ui]
             [reagent.core :as r]
             [hodgepodge.core :as hp]
             [goog.events]
@@ -23,15 +24,10 @@
   (goog.events/removeAll history)
 
   (let [storage hp/local-storage
-        [_ todos-initial-signal :as todos-initial] (todos/init)
-        app (devtools/connect todos-initial
-                              todos/view-model
-                              todos/view
-                              (-> (todos/new-control history)
-                                  (persistence/wrap-control todos-initial-signal storage :model nil))
-                              (-> (todos/new-reconcile history)
-                                  (persistence/wrap-reconcile storage :model nil))
-                              storage)]
+        app (ui/connect-reagent (-> (todos/new-spec history)
+                                    (persistence/wrap :on-init storage :model nil)
+                                    (devtools/wrap storage :devtools)))]
+
     ; start signaling on navigation events
     (goog.events/listen history EventType/NAVIGATE
                         #((:dispatch-signal app) [:component [:on-navigate (.-token %)]]))

--- a/src/frontend/core.cljs
+++ b/src/frontend/core.cljs
@@ -26,7 +26,7 @@
   (let [storage hp/local-storage
         app (ui/connect-reagent (-> (todos/new-spec history)
                                     (persistence/wrap storage :model nil)
-                                    (devtools/wrap storage :devtools)))]
+                                    (devtools/new-spec storage :devtools)))]
 
     ; start signaling on navigation events
     (goog.events/listen history EventType/NAVIGATE

--- a/src/frontend/core.cljs
+++ b/src/frontend/core.cljs
@@ -25,7 +25,7 @@
 
   (let [storage hp/local-storage
         app (ui/connect-reagent (-> (todos/new-spec history)
-                                    (persistence/wrap :on-init storage :model nil)
+                                    (persistence/wrap storage :model nil)
                                     (devtools/wrap storage :devtools)))]
 
     ; start signaling on navigation events

--- a/src/frontend/devtools.cljs
+++ b/src/frontend/devtools.cljs
@@ -7,13 +7,11 @@
 
 ;;;;;;;;;;;;;;;;;;; Init
 (defn -wrap-init
-  [component-init component-initial-signal]
+  [component-init]
   (fn init []
     (let [component-model (component-init)]
       {:component      component-model
-
        :initial-model  component-model
-       :initial-signal component-initial-signal
 
        ; list of [id signal]
        :signal-events  (list)
@@ -64,9 +62,7 @@
 
                ; and let component handle its initial signal
                ; note: outdated model is passed, but it's safe because :component model hasn't changed after clearing
-               (let [s (:initial-signal model)]
-                 (when-not (nil? s)
-                   (control model [:component s] dispatch)))))
+               (control model [:component :on-connect] dispatch)))
 
            [:on-toggle-signal id]
            (do
@@ -263,8 +259,7 @@
   "Wraps a component into devtools instnace.
   For replay to work correctly component is required to implement a :dev-identity action which returns the same model."
   [spec storage storage-key]
-  (-> {:init           (-wrap-init (:init spec) (:initial-signal spec))
-       :initial-signal :on-connect
+  (-> {:init           (-wrap-init (:init spec))
        :view-model     (-wrap-view-model (:view-model spec))
        :view           (-wrap-view (:view spec))
        :control        (-wrap-control (:control spec))
@@ -272,5 +267,5 @@
       ; blacklisted keys are provided on init and should not be overwritten by middleware
       ; (otherwise, on hot reload, we will not see changes after after modifying component init code)
       ; thus they also don't need to be saved
-      (persistence/wrap storage storage-key #{:initial-model :initial-signal})
+      (persistence/wrap storage storage-key #{:initial-model})
       ui/wrap-log))

--- a/src/frontend/devtools.cljs
+++ b/src/frontend/devtools.cljs
@@ -6,25 +6,26 @@
             [frontend.persistence-middleware :as persistence]))
 
 ;;;;;;;;;;;;;;;;;;; Init
-(defn init
-  "Creates a fresh dev-model instance using wrapped component init."
-  [[component-model component-signal :as _component-initial_]]
-  [{:component      component-model
+(defn -wrap-init
+  [component-init]
+  (fn init []
+    (let [[component-model component-signal] (component-init)]
+      [{:component      component-model
 
-    :initial-model  component-model
-    :initial-signal component-signal
+        :initial-model  component-model
+        :initial-signal component-signal
 
-    ; list of [id signal]
-    :signal-events  (list)
-    :next-signal-id 0
+        ; list of [id signal]
+        :signal-events  (list)
+        :next-signal-id 0
 
-    ; list of {id signal-id enabled? action}
-    :action-events  (list)
-    :next-action-id 0
+        ; list of {id signal-id enabled? action}
+        :action-events  (list)
+        :next-action-id 0
 
-    :persist?       false}
+        :persist?       false}
 
-   :on-connect])
+       :on-connect])))
 
 (defn -signal-event
   [id signal]
@@ -48,7 +49,7 @@
   (apply -update-action-events* model #(= (:id %) id) f args))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Control
-(defn new-control
+(defn -wrap-control
   [component-control]
   (fn control
     [model signal dispatch]
@@ -102,11 +103,14 @@
   (empty? (filter #(= (:signal-id %) signal-id)
                   (:action-events model))))
 
-(defn new-reconcile
+(defn -wrap-reconcile
   [component-reconcile]
   (fn reconcile
     [model action]
     (match action
+           :dev-identity
+           model
+
            :clear-history
            (assoc model :signal-events (list)
                         :action-events (list))
@@ -165,7 +169,7 @@
                  (update :next-action-id inc))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; View model
-(defn new-view-model
+(defn -wrap-view-model
   [component-view-model]
   (fn view-model
     [model]
@@ -240,9 +244,9 @@
    [:strong "Initial model:"]
    [:div (pr-str (:initial-model model))]])
 
-(defn new-view
+(defn -wrap-view
   [component-view]
-  (fn view
+  (fn devtools-view
     [model dispatch]
     [:div
      [component-view (:component-view-model model) (ui/tagged dispatch :component)]
@@ -256,21 +260,18 @@
                     :box-shadow "-2px 0 7px 0 rgba(0, 0, 0, 0.5)"}}
       [-devtools-view model dispatch]]]))
 
-(defn connect
-  "Given component's parts creates a devtools wrapper for it. Returns the same structure as ui/connect.
+;;;;;;;;;;;;;;;;;;;;;;;; Middleware
+(defn wrap
+  "Wraps a component into devtools instnace.
   For replay to work correctly component is required to implement a :dev-identity action which returns the same model."
-  [component-initial component-view-model component-view component-control component-reconcile storage]
-  ; blacklisted keys are provided by component init and should not be overwritten by middleware
-  ; (otherwise, on hot reload, we will not see changes after after modifying component init code)
-  ; thus they also don't need to be saved
-  (let [non-persisted-keys #{:initial-model :initial-signal}
-        [_ initial-signal :as initial] (init component-initial)]
-    (ui/connect initial
-                (new-view-model component-view-model)
-                (new-view component-view)
-                (-> (new-control component-control)
-                    (persistence/wrap-control initial-signal storage :devtools non-persisted-keys)
-                    ui/wrap-log-signals)
-                (-> (new-reconcile component-reconcile)
-                    (persistence/wrap-reconcile storage :devtools non-persisted-keys)
-                    ui/wrap-log-actions))))
+  [spec storage storage-key]
+  (-> {:init       (-wrap-init (:init spec))
+       :view-model (-wrap-view-model (:view-model spec))
+       :view       (-wrap-view (:view spec))
+       :control    (-wrap-control (:control spec))
+       :reconcile  (-wrap-reconcile (:reconcile spec))}
+      ; blacklisted keys are provided on init and should not be overwritten by middleware
+      ; (otherwise, on hot reload, we will not see changes after after modifying component init code)
+      ; thus they also don't need to be saved
+      (persistence/wrap :on-connect storage storage-key #{:initial-model :initial-signal})
+      ui/wrap-log))

--- a/src/frontend/devtools.cljs
+++ b/src/frontend/devtools.cljs
@@ -255,7 +255,7 @@
       [-devtools-view model dispatch]]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Middleware
-(defn wrap
+(defn new-spec
   "Wraps a component into devtools instnace.
   For replay to work correctly component is required to implement a :dev-identity action which returns the same model."
   [spec storage storage-key]

--- a/src/frontend/persistence-middleware.cljs
+++ b/src/frontend/persistence-middleware.cljs
@@ -3,9 +3,7 @@
 (ns frontend.persistence-middleware
   (:require [cljs.core.match :refer-macros [match]]))
 
-(defn wrap-control
-  "On load-signal middleware will load the model from storage and send the signal further with updated model to the component.
-  Blacklist should contain model keys which will not be loaded from storage."
+(defn -wrap-control
   [control load-signal storage key load-blacklist]
   (fn wrapped-control
     [model signal dispatch]
@@ -27,8 +25,7 @@
             ; with updated model hand signal further to component
             (control new-model signal dispatch)))))))
 
-(defn wrap-reconcile
-  "Blacklist should contain model keys which will not be saved to storage."
+(defn -wrap-reconcile
   [reconcile storage key save-blacklist]
   (fn wrapped-reconcile
     [model action]
@@ -41,3 +38,11 @@
                  whitelist (clojure.set/difference (set (keys result)) save-blacklist)]
              (assoc! storage key (select-keys result whitelist))
              result))))
+
+(defn wrap
+  "On load-signal middleware will load the model from storage and send the signal further with updated model to the component.
+  Blacklist should contain model keys which will not be saved and loaded."
+  [spec load-signal storage key blacklist]
+  (-> spec
+      (update :control -wrap-control load-signal storage key blacklist)
+      (update :reconcile -wrap-reconcile storage key blacklist)))

--- a/src/frontend/persistence-middleware.cljs
+++ b/src/frontend/persistence-middleware.cljs
@@ -42,7 +42,8 @@
 (defn wrap
   "On load-signal middleware will load the model from storage and send the signal further with updated model to the component.
   Blacklist should contain model keys which will not be saved and loaded."
-  [spec load-signal storage key blacklist]
+  [spec storage key blacklist]
+  {:pre [(not (nil? (:initial-signal spec)))]}
   (-> spec
-      (update :control -wrap-control load-signal storage key blacklist)
+      (update :control -wrap-control (:initial-signal spec) storage key blacklist)
       (update :reconcile -wrap-reconcile storage key blacklist)))

--- a/src/frontend/persistence-middleware.cljs
+++ b/src/frontend/persistence-middleware.cljs
@@ -4,11 +4,11 @@
   (:require [cljs.core.match :refer-macros [match]]))
 
 (defn -wrap-control
-  [control load-signal storage key load-blacklist]
+  [control storage key load-blacklist]
   (fn wrapped-control
     [model signal dispatch]
-    (if-not (= signal load-signal)
-      ; not loaded-signal - hand signal further to component
+    (if-not (= signal :on-connect)
+      ; hand signal further to component
       (control model signal dispatch)
 
       ; else
@@ -43,7 +43,6 @@
   "On load-signal middleware will load the model from storage and send the signal further with updated model to the component.
   Blacklist should contain model keys which will not be saved and loaded."
   [spec storage key blacklist]
-  {:pre [(not (nil? (:initial-signal spec)))]}
   (-> spec
-      (update :control -wrap-control (:initial-signal spec) storage key blacklist)
+      (update :control -wrap-control storage key blacklist)
       (update :reconcile -wrap-reconcile storage key blacklist)))

--- a/src/frontend/todos.cljs
+++ b/src/frontend/todos.cljs
@@ -17,13 +17,12 @@
 
 (defn -init
   []
-  [{:field      ""
-    :visibility :all
-    ; list of maps {:id :title :completed :editing}
-    :todos      (list (-init-todo 1 "Finish this project")
-                      (-init-todo 2 "Take a bath"))
-    :next-id    3}
-   :on-init])
+  {:field      ""
+   :visibility :all
+   ; list of maps {:id :title :completed :editing}
+   :todos      (list (-init-todo 1 "Finish this project")
+                     (-init-todo 2 "Take a bath"))
+   :next-id    3})
 
 (defn -update-todos*
   [model pred f & args]
@@ -153,12 +152,12 @@
              (if (clojure.string/blank? title)
                (-remove-todo model id)
                (-update-todos model #(assoc % :editing? false
-                                             :original-title ""))))
+                                              :original-title ""))))
 
            [:cancel-editing id]
            (-update-todo model id #(assoc % :editing? false
-                                           :title (:original-title %)
-                                           :original-title ""))
+                                            :title (:original-title %)
+                                            :original-title ""))
 
            [:update-todo id val]
            (-update-todo model id assoc :title val)
@@ -285,8 +284,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;; Spec
 (defn new-spec
   [history]
-  {:init       -init
-   :view-model -view-model
-   :view       -view
-   :control    (-new-control history)
-   :reconcile  (-new-reconcile history)})
+  {:init           -init
+   :initial-signal :on-init
+   :view-model     -view-model
+   :view           -view
+   :control        (-new-control history)
+   :reconcile      (-new-reconcile history)})

--- a/src/frontend/todos.cljs
+++ b/src/frontend/todos.cljs
@@ -63,7 +63,7 @@
   (fn control
     [_model_ signal dispatch]
     (match signal
-           :on-init
+           :on-connect
            (do
              ; dispatch the current route
              (dispatch [:navigate (.getToken history)])
@@ -71,8 +71,7 @@
              (dispatch :sample-action))
 
            ; this signal must come from the component owner which listens to history events
-           [:on-navigate token]
-           (dispatch [:navigate token])
+           [:on-navigate token] (dispatch [:navigate token])
 
            [:on-update-field val] (dispatch [:update-field val])
            :on-add (dispatch :add)
@@ -285,7 +284,6 @@
 (defn new-spec
   [history]
   {:init           -init
-   :initial-signal :on-init
    :view-model     -view-model
    :view           -view
    :control        (-new-control history)

--- a/src/frontend/todos.cljs
+++ b/src/frontend/todos.cljs
@@ -7,7 +7,7 @@
             [goog.history.EventType :as EventType]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Model
-(defn init-todo
+(defn -init-todo
   [id title]
   {:id             id
    :title          title
@@ -15,51 +15,51 @@
    :original-title ""
    :editing?       false})
 
-(defn init
+(defn -init
   []
   [{:field      ""
     :visibility :all
     ; list of maps {:id :title :completed :editing}
-    :todos      (list (init-todo 1 "Finish this project")
-                      (init-todo 2 "Take a bath"))
+    :todos      (list (-init-todo 1 "Finish this project")
+                      (-init-todo 2 "Take a bath"))
     :next-id    3}
    :on-init])
 
-(defn update-todos*
+(defn -update-todos*
   [model pred f & args]
   (s/transform [:todos s/ALL pred]
                #(apply f % args)
                model))
 
-(defn update-todo
+(defn -update-todo
   [model id f & args]
-  (apply update-todos* model #(= (:id %) id) f args))
+  (apply -update-todos* model #(= (:id %) id) f args))
 
-(defn update-todos
+(defn -update-todos
   [model f & args]
-  (apply update-todos* model (constantly true) f args))
+  (apply -update-todos* model (constantly true) f args))
 
-(defn find-todo
+(defn -find-todo
   [model id]
   (->> (:todos model)
        (filter #(= (:id %) id))
        first))
 
-(defn remove-todos
+(defn -remove-todos
   [model pred]
   (update model :todos #(remove pred %)))
 
-(defn remove-todo
+(defn -remove-todo
   [model id]
-  (remove-todos model #(= (:id %) id)))
+  (-remove-todos model #(= (:id %) id)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Control
-(def visibility-spec
+(def -visibility-spec
   [{:key :all :title "All" :href "#" :token ""}
    {:key :active :title "Active" :href "#/active" :token "/active"}
    {:key :completed :title "Completed" :href "#/completed" :token "/completed"}])
 
-(defn new-control
+(defn -new-control
   [history]
   (fn control
     [_model_ signal dispatch]
@@ -87,7 +87,7 @@
            :on-clear-completed (dispatch :clear-completed))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Reconcile
-(defn new-reconcile
+(defn -new-reconcile
   [history]
   (fn reconcile
     [model action]
@@ -113,7 +113,7 @@
                (println "      REPLACING TOKEN TO" (pr-str token))
                (.replaceToken history token))
 
-             (if-let [match (->> visibility-spec
+             (if-let [match (->> -visibility-spec
                                  (filter #(= (:token %) token))
                                  first)]
                (do
@@ -132,45 +132,45 @@
                (-> model
                    (assoc :field "")
                    (update :next-id inc)
-                   (update :todos concat [(init-todo (:next-id model) title)]))))
+                   (update :todos concat [(-init-todo (:next-id model) title)]))))
 
            [:toggle id]
-           (update-todo model id update :completed? not)
+           (-update-todo model id update :completed? not)
 
            :toggle-all
            (let [all-completed? (every? :completed? (:todos model))]
-             (update-todos model assoc :completed? (not all-completed?)))
+             (-update-todos model assoc :completed? (not all-completed?)))
 
            [:start-editing id]
            (-> model
-               (update-todos #(assoc % :editing? (= (:id %) id)))
-               (update-todo id #(assoc % :original-title (:title %))))
+               (-update-todos #(assoc % :editing? (= (:id %) id)))
+               (-update-todo id #(assoc % :original-title (:title %))))
 
            [:stop-editing id]
-           (let [title (-> (find-todo model id)
+           (let [title (-> (-find-todo model id)
                            :title
                            clojure.string/trim)]
              (if (clojure.string/blank? title)
-               (remove-todo model id)
-               (update-todos model #(assoc % :editing? false
+               (-remove-todo model id)
+               (-update-todos model #(assoc % :editing? false
                                              :original-title ""))))
 
            [:cancel-editing id]
-           (update-todo model id #(assoc % :editing? false
+           (-update-todo model id #(assoc % :editing? false
                                            :title (:original-title %)
                                            :original-title ""))
 
            [:update-todo id val]
-           (update-todo model id assoc :title val)
+           (-update-todo model id assoc :title val)
 
            [:remove id]
-           (remove-todo model id)
+           (-remove-todo model id)
 
            :clear-completed
-           (remove-todos model :completed?))))
+           (-remove-todos model :completed?))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; View model
-(defn view-model
+(defn -view-model
   [model]
   (assoc model
     :todos (filter (case (:visibility model)
@@ -189,32 +189,32 @@
     :all-completed? (every? :completed? (:todos model))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; View
-(defn enter-key?
+(defn -enter-key?
   [e]
   (= (.-keyCode e) 13))
 
-(defn escape-key?
+(defn -escape-key?
   [e]
   (= (.-keyCode e) 27))
 
-(defn view-header
+(defn -view-header
   [field dispatch]
   [:header.header
    [:h1 "todos"]
    [:input.new-todo {:placeholder "What needs to be done?"
                      :value       field
                      :on-change   #(dispatch [:on-update-field (.. % -target -value)])
-                     :on-key-down #(when (enter-key? %) (dispatch :on-add))}]])
+                     :on-key-down #(when (-enter-key? %) (dispatch :on-add))}]])
 
-(defn view-todo-input
+(defn -view-todo-input
   "Note that |editing?| is passed only to trigger :component-did-update to set focus on the state change."
   [_id_ _title_ _editing?_ _dispatch_]
   (r/create-class {:reagent-render
                    (fn [id title _editing?_ dispatch]
                      [:input.edit {:value       title
                                    :on-change   #(dispatch [:on-update-todo id (.. % -target -value)])
-                                   :on-key-down #(cond (enter-key? %) (dispatch [:on-stop-editing id])
-                                                       (escape-key? %) (dispatch [:on-cancel-editing id]))
+                                   :on-key-down #(cond (-enter-key? %) (dispatch [:on-stop-editing id])
+                                                       (-escape-key? %) (dispatch [:on-cancel-editing id]))
                                    :on-blur     #(dispatch [:on-stop-editing id])}])
 
                    :component-did-update
@@ -226,7 +226,7 @@
                    (fn [this]
                      (.focus (r/dom-node this)))}))
 
-(defn view-todo
+(defn -view-todo
   [{:keys [id title editing? completed?] :as _todo_} dispatch]
   [:li {:class (cond editing? "editing" completed? "completed")}
    [:div.view
@@ -238,9 +238,9 @@
 
     [:button.destroy {:on-click #(dispatch [:on-remove id])}]]
 
-   [view-todo-input id title editing? dispatch]])
+   [-view-todo-input id title editing? dispatch]])
 
-(defn view-todo-list
+(defn -view-todo-list
   [todos all-completed? dispatch]
   [:section.main
    [:input.toggle-all {:type      "checkbox"
@@ -251,16 +251,16 @@
    [:ul.todo-list
     (for [todo todos]
       ^{:key (:id todo)}
-      [view-todo todo dispatch])]])
+      [-view-todo todo dispatch])]])
 
-(defn view-footer
+(defn -view-footer
   [active-count has-completed-todos? visibility dispatch]
   [:footer.footer
    [:span.todo-count
     [:strong active-count] (str " " (if (= active-count 1) "item" "items")
                                 " left")]
    [:ul.filters
-    (for [{:keys [key title href]} visibility-spec]
+    (for [{:keys [key title href]} -visibility-spec]
       ^{:key key}
       [:li
        [:a
@@ -271,13 +271,22 @@
    (if has-completed-todos?
      [:button.clear-completed {:on-click #(dispatch :on-clear-completed)} "Clear completed"])])
 
-(defn view
+(defn -view
   [{:keys [field todos has-todos? active-count has-completed-todos? all-completed? visibility] :as _view-model_}
    dispatch]
   [:section.todoapp
-   [view-header field dispatch]
+   [-view-header field dispatch]
 
    (if has-todos?
      [:div
-      [view-todo-list todos all-completed? dispatch]
-      [view-footer active-count has-completed-todos? visibility dispatch]])])
+      [-view-todo-list todos all-completed? dispatch]
+      [-view-footer active-count has-completed-todos? visibility dispatch]])])
+
+;;;;;;;;;;;;;;;;;;;;;;;; Spec
+(defn new-spec
+  [history]
+  {:init       -init
+   :view-model -view-model
+   :view       -view
+   :control    (-new-control history)
+   :reconcile  (-new-reconcile history)})

--- a/src/frontend/ui.cljs
+++ b/src/frontend/ui.cljs
@@ -4,31 +4,32 @@
             [cljs.pprint]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Core
-(defn connect
-  "Initial model must be immutable. Initial signal can be nil if it should not be fired.
-  Control can be a non-pure function.
-  View-model, view and reconcile must be pure functions.
+(defn connect-reagent
+  "Given a component spec map returns a connected component which can be rendered using Reagent.
+
+  :control can be a non-pure function, :init, :view-model, :view and :reconcile must be pure functions.
 
   Returns a map with:
-      :view,
-      :dispatch-signal (it can be used to dispatch signal not only from the view),
+      :view (Reagent view function),
+      :dispatch-signal (it can be used to dispatch signals not only from the view),
       :model ratom (this is exposed mainly for debugging),
       :dispatch-action (this is exposed mainly for debugging).
 
   Data flow:
   model -> (view-model) -> (view) -signal-> (control) -action-> (reconcile) -> model -> etc."
-  [[model signal :as _initial_] view-model view control reconcile]
-  ; for now dispatch functions return nil to make API even smaller
-  (let [model-atom (r/atom model)
-        dispatch-action (fn [a] (swap! model-atom reconcile a) nil)
-        dispatch-signal (fn [s] (control @model-atom s dispatch-action) nil)
-        connected-view (fn [] [view (view-model @model-atom) dispatch-signal])]
-    (some-> signal dispatch-signal)
+  [{:keys [init view-model view control reconcile] :as _spec_}]
+  (let [[model initial-signal] (init)
+        model-ratom (r/atom model)]
+    ; for now dispatch functions return nil to make API even smaller
+    (letfn [(dispatch-action [action] (swap! model-ratom reconcile action) nil)
+            (dispatch-signal [signal] (control @model-ratom signal dispatch-action) nil)
+            (reagent-view [] [view (view-model @model-ratom) dispatch-signal])]
+      (some-> initial-signal dispatch-signal)
 
-    {:view            connected-view
-     :dispatch-signal dispatch-signal
-     :model           model-atom
-     :dispatch-action dispatch-action}))
+      {:view            reagent-view
+       :dispatch-signal dispatch-signal
+       :model           model-ratom
+       :dispatch-action dispatch-action})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; Utils
 (defn tagged
@@ -39,25 +40,19 @@
     [x]
     (f [tag x])))
 
-;;;;;;;;;;;;;;;;;;;;;;;; Control Middlewares
-(defn wrap-log-signals
-  [control]
-  (fn wrapped-control
-    [model signal dispatch]
-    (println "signal =" signal)
-    (control model signal dispatch)))
-
-;;;;;;;;;;;;;;;;;;;;;;;; Reconcile Middlewares
-(defn wrap-log-actions
-  [reconcile]
-  (fn wrapped-reconcile
-    [model action]
-    (println "  action =" action)
-    (let [result (reconcile model action)]
-      ;(cljs.pprint/pprint model)
-      ;(print "->")
-      ;(cljs.pprint/pprint result)
-      ;(println "   " model)
-      ;(println "     ->")
-      ;(println "   " result)
-      result)))
+;;;;;;;;;;;;;;;;;;;;;;;; Middleware
+(defn wrap-log
+  [spec]
+  (-> spec
+      (update :control #(fn control
+                         [model signal dispatch]
+                         (println "signal =" signal)
+                         (% model signal dispatch)))
+      (update :reconcile #(fn reconcile
+                           [model action]
+                           (println "  action =" action)
+                           (let [result (% model action)]
+                             ;(println "   " model)
+                             ;(println "     ->")
+                             ;(println "   " result)
+                             result)))))

--- a/src/frontend/ui.cljs
+++ b/src/frontend/ui.cljs
@@ -17,8 +17,8 @@
 
   Data flow:
   model -> (view-model) -> (view) -signal-> (control) -action-> (reconcile) -> model -> etc."
-  [{:keys [init view-model view control reconcile] :as _spec_}]
-  (let [[model initial-signal] (init)
+  [{:keys [init initial-signal view-model view control reconcile] :as _spec_}]
+  (let [model (init)
         model-ratom (r/atom model)]
     ; for now dispatch functions return nil to make API even smaller
     (letfn [(dispatch-action [action] (swap! model-ratom reconcile action) nil)

--- a/src/frontend/ui.cljs
+++ b/src/frontend/ui.cljs
@@ -9,7 +9,7 @@
 
   :control can be a non-pure function, :init, :view-model, :view and :reconcile must be pure functions.
 
-  Returns a map with:
+  Dispatches :on-connect signal and returns a map with:
       :view (Reagent view function),
       :dispatch-signal (it can be used to dispatch signals not only from the view),
       :model ratom (this is exposed mainly for debugging),
@@ -17,14 +17,14 @@
 
   Data flow:
   model -> (view-model) -> (view) -signal-> (control) -action-> (reconcile) -> model -> etc."
-  [{:keys [init initial-signal view-model view control reconcile] :as _spec_}]
+  [{:keys [init view-model view control reconcile] :as _spec_}]
   (let [model (init)
         model-ratom (r/atom model)]
     ; for now dispatch functions return nil to make API even smaller
     (letfn [(dispatch-action [action] (swap! model-ratom reconcile action) nil)
             (dispatch-signal [signal] (control @model-ratom signal dispatch-action) nil)
             (reagent-view [] [view (view-model @model-ratom) dispatch-signal])]
-      (some-> initial-signal dispatch-signal)
+      (dispatch-signal :on-connect)
 
       {:view            reagent-view
        :dispatch-signal dispatch-signal


### PR DESCRIPTION
This merge updates a UI pattern:
1. by adding a notion of a "component spec", which is basically a map with all the functions which define a component: {:init :view-model :view :control :reconcile};
2. devtools and middlewares now simply take a component spec as an input and return a new spec;
3. explicitly specified "initial-signal" is removed (instead :on-connect is always invoked at start as it was originally);
4. ui/connect is renamed to ui/connect-reagent.
